### PR TITLE
removed require on A record

### DIFF
--- a/manifests/mx.pp
+++ b/manifests/mx.pp
@@ -28,7 +28,7 @@ define bind::mx (
     target  => "/etc/bind/pri/${zone}.conf",
     content => template('bind/mx-record.erb'),
     notify  => Service['bind9'],
-    require => [Bind::Zone[$zone], Bind::A[$host]],
+    require => Bind::Zone[$zone],
   }
 
 }


### PR DESCRIPTION
This require break when we have an external MX, like googleApps or else.
As it's an external MX, it's useless (and really NOT recommanded) to
manage its A record ;).
