### PR TITLE
bind::mx: remove problematic require

### DIFF
--- a/manifests/mx.pp
+++ b/manifests/mx.pp
@@ -28,7 +28,6 @@ define bind::mx (
     target  => "/etc/bind/pri/${zone}.conf",
     content => template('bind/mx-record.erb'),
     notify  => Service['bind9'],
-    require => Bind::Zone[$zone],
   }
 
 }


### PR DESCRIPTION
Dependencies within this module must largely be assured by the use
of concat. This require seems useless and can actually create
dependency loops.
