### PR TITLE
Add check-names warn; in bind zone templates

### DIFF
--- a/templates/zone-master.erb
+++ b/templates/zone-master.erb
@@ -13,4 +13,5 @@ zone "<%=name%>" IN {
 <% end -%>
   allow-query { any; };
   notify yes;
+  check-names warn;
 };


### PR DESCRIPTION
If a dns entry contains the '_' character, the zone containing this entry is dropped. Adding check-names warn; avoid to drop the zones.
