### PR TITLE
fix error 'named-checkconf -jz /etc/bind/named.conf is not qualified and...

### DIFF
--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -39,6 +39,7 @@ class bind::base inherits bind::params {
   exec {'reload bind9':
     command     => "service ${bind::params::service_name} reload",
     onlyif      => "named-checkconf -jz ${bind::params::config_base_dir}/${bind::params::named_conf_name}",
+    path        => '/sbin:/usr/sbin:/bin:/usr/bin',
     refreshonly => true,
   }
 


### PR DESCRIPTION
... no path was specified. Please qualify the command or specify a path.' message that appears with recent puppet version
