### PR TITLE
changed @zone_ns from string to array to enable multiple NS records for ...

### DIFF
--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -52,7 +52,7 @@ define bind::zone (
   validate_string($zone_refresh)
   validate_string($zone_retry)
   validate_string($zone_expiracy)
-  validate_string($zone_ns)
+  validate_array($zone_ns)
   validate_string($zone_origin)
 
   if ($is_slave and $is_dynamic) {
@@ -94,7 +94,7 @@ define bind::zone (
 ## END of slave
       } else {
         validate_re($zone_contact, '^\S+$', "Wrong contact value for ${name}!")
-        validate_re($zone_ns, '^\S+$', "Wrong ns value for ${name}!")
+#        validate_re($zone_ns, '^\S+$', "Wrong ns value for ${name}!")
         validate_re($zone_serial, '^\d+$', "Wrong serial value for ${name}!")
         validate_re($zone_ttl, '^\d+$', "Wrong ttl value for ${name}!")
 

--- a/templates/zone-header.erb
+++ b/templates/zone-header.erb
@@ -1,12 +1,13 @@
 ; File managed by puppet
 $TTL <%= @zone_ttl %>
-@ IN SOA <%= @name %>. <%= @zone_contact %>. (
+@ IN SOA <%= @zone_ns[0] %>. <%= @zone_contact %>. (
       <%= @zone_serial %>  ; serial
       <%= @zone_refresh %> ; refresh
       <%= @zone_retry %>   ; retry
       <%= @zone_expiracy %>; expiracy
       <%= @zone_ttl %> )   ; TTL
-      IN NS <%= @zone_ns %>.
+<% @zone_ns.each do |ns| %>      IN NS <%= ns %>.
+<% end %>
 <% if @zone_origin -%>
 $ORIGIN <%= @zone_origin %>.
 <% end -%>


### PR DESCRIPTION
...the domain.

I commented out the "validate_re($zone_ns..." in line 97 of zone.pp because I had no good idea how to solve this.

additionally fixed SOA record to print name of the primary NS (first value in array; see also http://www.ripe.net/ripe/docs/ripe-203).

So "bind::zone" should be 
```
bind::zone {'test.tld':
  zone_contact => 'contact.test.tld',
  zone_ns      => [ 'ns0.test.tld', 'ns1.test.tld', ],
  zone_serial  => '2012112901',
  zone_ttl     => '604800',
  zone_origin  => 'test.tld',
}
```
when using this patch - which leads to this zonefile:

```
; File managed by puppet
$TTL 604800
@ IN SOA ns0.test.tld. contact.test.tld. (
      2012112901  ; serial
      3h ; refresh
      1h   ; retry
      1w; expiracy
      604800 )   ; TTL
      IN NS ns0.test.tld.
      IN NS ns1.test.tld.

$ORIGIN test.tld.
```