### PR TITLE
Linting and spec corrections

### DIFF
--- a/manifests/a.pp
+++ b/manifests/a.pp
@@ -13,9 +13,9 @@
 define bind::a(
   $zone,
   $hash_data,
-  $ensure = present,
-  $zone_arpa = '',
-  $ptr    = true,
+  $ensure           = present,
+  $zone_arpa        = undef,
+  $ptr              = true,
   $content_template = undef,
 ) {
 
@@ -28,7 +28,7 @@ define bind::a(
   validate_hash($hash_data)
   validate_bool($ptr)
 
-  if ($ptr and $zone_arpa == '') {
+  if ($ptr and !$zone_arpa) {
     fail 'You need zone_arpa if you want the PTR!'
   }
 

--- a/manifests/generate.pp
+++ b/manifests/generate.pp
@@ -74,11 +74,12 @@ define bind::generate(
   $record_type,
   $lhs,
   $rhs,
-  $ensure=present,
-  $record_class='',
-  $ttl='') {
+  $ensure       = present,
+  $record_class = undef,
+  $ttl          = undef,
+) {
 
-  include bind::params
+  include ::bind::params
 
   validate_string($ensure)
   validate_re($ensure, ['present', 'absent'],
@@ -92,7 +93,7 @@ define bind::generate(
   validate_string($record_class)
   validate_string($ttl)
 
-  concat::fragment {"${zone}.${record_type}.${range}.generate":
+  ::concat::fragment {"${zone}.${record_type}.${range}.generate":
     ensure  => $ensure,
     target  => "${bind::params::pri_directory}/${zone}.conf",
     content => template('bind/generate.erb'),

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,5 +44,5 @@
 # }
 #
 class bind {
-    include bind::base
+    include ::bind::base
 }

--- a/manifests/key.pp
+++ b/manifests/key.pp
@@ -17,7 +17,7 @@ define bind::key(
   $algorithm = 'hmac-md5',
 ) {
 
-  include bind::params
+  include ::bind::params
 
   validate_string($ensure)
   validate_re($ensure, ['present', 'absent'],

--- a/manifests/mx.pp
+++ b/manifests/mx.pp
@@ -13,8 +13,8 @@ define bind::mx (
   $host,
   $priority,
   $ensure = present,
-  $owner = '',
-  $ttl = ''
+  $owner  = undef,
+  $ttl    = undef,
 ) {
 
   validate_string($ensure)

--- a/manifests/record.pp
+++ b/manifests/record.pp
@@ -28,9 +28,9 @@ define bind::record (
   $zone,
   $hash_data,
   $record_type,
-  $ensure   = present,
-  $ptr_zone = '',
-  $content_template = '',
+  $ensure           = present,
+  $ptr_zone         = undef,
+  $content_template = undef,
 ) {
 
   validate_string($ensure)
@@ -44,7 +44,7 @@ define bind::record (
   validate_hash($hash_data)
 
   $records_template = $content_template ?{
-    ''      => 'bind/default-record.erb',
+    undef   => 'bind/default-record.erb',
     default => $content_template,
   }
 

--- a/manifests/record.pp
+++ b/manifests/record.pp
@@ -29,8 +29,8 @@ define bind::record (
   $hash_data,
   $record_type,
   $ensure           = present,
+  $content_template = 'bind/default-record.erb',
   $ptr_zone         = undef,
-  $content_template = undef,
 ) {
 
   validate_string($ensure)
@@ -43,15 +43,10 @@ define bind::record (
   validate_string($content_template)
   validate_hash($hash_data)
 
-  $records_template = $content_template ?{
-    undef   => 'bind/default-record.erb',
-    default => $content_template,
-  }
-
   concat::fragment {"${zone}.${record_type}.${name}":
     ensure  => $ensure,
     target  => "${bind::params::pri_directory}/${zone}.conf",
-    content => template($records_template),
+    content => template($content_template),
     notify  => Service['bind9'],
   }
 

--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -22,21 +22,21 @@ define bind::zone (
   $is_dynamic      = false,
   $is_slave        = false,
   $allow_update    = [],
-  $transfer_source = '',
-  $zone_ttl        = '',
-  $zone_contact    = '',
-  $zone_serial     = '',
+  $transfer_source = undef,
+  $zone_ttl        = undef,
+  $zone_contact    = undef,
+  $zone_serial     = undef,
   $zone_refresh    = '3h',
   $zone_retry      = '1h',
   $zone_expiracy   = '1w',
-  $zone_ns         = '',
-  $zone_xfers      = '',
-  $zone_masters    = '',
-  $zone_origin     = '',
-  $zone_notify     = ''
+  $zone_ns         = undef,
+  $zone_xfers      = undef,
+  $zone_masters    = undef,
+  $zone_origin     = undef,
+  $zone_notify     = undef,
 ) {
 
-  include bind::params
+  include ::bind::params
 
   validate_string($ensure)
   validate_re($ensure, ['present', 'absent'],
@@ -59,7 +59,7 @@ define bind::zone (
     fail "Zone '${name}' cannot be slave AND dynamic!"
   }
 
-  if ($transfer_source != '' and ! $is_slave) {
+  if ($transfer_source and ! $is_slave) {
     fail "Zone '${name}': transfer_source can be set only for slave zones!"
   }
 

--- a/spec/defines/bind_a_spec.rb
+++ b/spec/defines/bind_a_spec.rb
@@ -126,7 +126,7 @@ describe 'bind::a' do
           :zone             => 'foo.example.com',
           :record_type      => 'A',
           :hash_data        => {},
-          :content_template => nil,
+          :content_template => 'bind/default-record.erb',
         ) }
       end
 
@@ -143,7 +143,7 @@ describe 'bind::a' do
           :zone             => 'foo.example.com',
           :record_type      => 'A',
           :hash_data        => {},
-          :content_template => nil,
+          :content_template => 'bind/default-record.erb',
         ) }
 
         it { should contain_bind__record('PTR foo.example.com').with(
@@ -152,7 +152,7 @@ describe 'bind::a' do
           :record_type      => 'PTR',
           :ptr_zone         => 'foo.example.com',
           :hash_data        => {},
-          :content_template => nil,
+          :content_template => 'bind/default-record.erb',
         ) }
       end
 
@@ -168,7 +168,7 @@ describe 'bind::a' do
           :zone             => 'foo.example.com',
           :record_type      => 'A',
           :hash_data        => {'*' => { 'owner' => 'foo.example.com', }},
-          :content_template => nil,
+          :content_template => 'bind/default-record.erb',
         ) }
       end
 
@@ -184,7 +184,7 @@ describe 'bind::a' do
           :zone             => 'foo.example.com',
           :record_type      => 'A',
           :hash_data        => {'' => { 'owner' => 'foo.example.com', }},
-          :content_template => nil,
+          :content_template => 'bind/default-record.erb',
         ) }
       end
 

--- a/spec/defines/bind_a_spec.rb
+++ b/spec/defines/bind_a_spec.rb
@@ -121,13 +121,13 @@ describe 'bind::a' do
           :ptr       => false
         } }
 
-        it { should contain_bind__record('foo.example.com').with(
+        it { should contain_bind__record('foo.example.com').with({
           :ensure           => 'present',
           :zone             => 'foo.example.com',
           :record_type      => 'A',
           :hash_data        => {},
           :content_template => 'bind/default-record.erb',
-        ) }
+        }) }
       end
 
       context 'when using using ptr' do
@@ -138,22 +138,22 @@ describe 'bind::a' do
           :zone_arpa => 'foobar.arpa'
         } }
 
-        it { should contain_bind__record('foo.example.com').with(
+        it { should contain_bind__record('foo.example.com').with({
           :ensure           => 'present',
           :zone             => 'foo.example.com',
           :record_type      => 'A',
           :hash_data        => {},
           :content_template => 'bind/default-record.erb',
-        ) }
+        }) }
 
-        it { should contain_bind__record('PTR foo.example.com').with(
+        it { should contain_bind__record('PTR foo.example.com').with({
           :ensure           => 'present',
           :zone             => 'foobar.arpa',
           :record_type      => 'PTR',
           :ptr_zone         => 'foo.example.com',
           :hash_data        => {},
           :content_template => 'bind/default-record.erb',
-        ) }
+        }) }
       end
 
       context 'when using star catchall' do
@@ -163,13 +163,13 @@ describe 'bind::a' do
           :ptr       => false,
         } }
 
-        it { should contain_bind__record('foo.example.com').with(
+        it { should contain_bind__record('foo.example.com').with({
           :ensure           => 'present',
           :zone             => 'foo.example.com',
           :record_type      => 'A',
           :hash_data        => {'*' => { 'owner' => 'foo.example.com', }},
           :content_template => 'bind/default-record.erb',
-        ) }
+        }) }
       end
 
       context 'when using blank host' do
@@ -179,13 +179,13 @@ describe 'bind::a' do
           :ptr       => false,
         } }
 
-        it { should contain_bind__record('foo.example.com').with(
+        it { should contain_bind__record('foo.example.com').with({
           :ensure           => 'present',
           :zone             => 'foo.example.com',
           :record_type      => 'A',
           :hash_data        => {'' => { 'owner' => 'foo.example.com', }},
           :content_template => 'bind/default-record.erb',
-        ) }
+        }) }
       end
 
       context 'when passing syntactically incorrect domain name' do

--- a/spec/defines/bind_a_spec.rb
+++ b/spec/defines/bind_a_spec.rb
@@ -106,7 +106,6 @@ describe 'bind::a' do
           :zone      => 'foo.example.com',
           :hash_data => {},
           :ptr       => true,
-          :zone_arpa => ''
         } }
 
         it 'should fail' do
@@ -127,7 +126,7 @@ describe 'bind::a' do
           :zone             => 'foo.example.com',
           :record_type      => 'A',
           :hash_data        => {},
-          :content_template => ''
+          :content_template => nil,
         ) }
       end
 
@@ -144,7 +143,7 @@ describe 'bind::a' do
           :zone             => 'foo.example.com',
           :record_type      => 'A',
           :hash_data        => {},
-          :content_template => ''
+          :content_template => nil,
         ) }
 
         it { should contain_bind__record('PTR foo.example.com').with(
@@ -153,7 +152,7 @@ describe 'bind::a' do
           :record_type      => 'PTR',
           :ptr_zone         => 'foo.example.com',
           :hash_data        => {},
-          :content_template => ''
+          :content_template => nil,
         ) }
       end
 
@@ -169,7 +168,7 @@ describe 'bind::a' do
           :zone             => 'foo.example.com',
           :record_type      => 'A',
           :hash_data        => {'*' => { 'owner' => 'foo.example.com', }},
-          :content_template => ''
+          :content_template => nil,
         ) }
       end
 
@@ -185,7 +184,7 @@ describe 'bind::a' do
           :zone             => 'foo.example.com',
           :record_type      => 'A',
           :hash_data        => {'' => { 'owner' => 'foo.example.com', }},
-          :content_template => ''
+          :content_template => nil,
         ) }
       end
 

--- a/spec/defines/bind_generate_spec.rb
+++ b/spec/defines/bind_generate_spec.rb
@@ -227,11 +227,11 @@ describe 'bind::generate' do
           :lhs         => 'dhcp-$',
           :rhs         => '10.10.0.$',
         } }
-        it { should contain_concat__fragment('test.tld.A.2-100.generate').with(
+        it { should contain_concat__fragment('test.tld.A.2-100.generate').with({
           :ensure  => 'present',
           :target  => "#{confdir}/pri/test.tld.conf",
           :content => "\$GENERATE 2-100 dhcp-\$   A 10.10.0.\$ ; a-record\n"
-        ) }
+        }) }
       end
 
       context 'when using example 2' do
@@ -243,11 +243,11 @@ describe 'bind::generate' do
           :lhs         => 'dhcp-$',
           :rhs         => '10.10.0.$',
         } }
-        it { should contain_concat__fragment('test.tld.CNAME.2-100.generate').with(
+        it { should contain_concat__fragment('test.tld.CNAME.2-100.generate').with({
           :ensure  => 'present',
           :target  => "#{confdir}/pri/test.tld.conf",
           :content => "\$GENERATE 2-100 dhcp-\$   CNAME 10.10.0.\$ ; a-record\n"
-        ) }
+        }) }
       end
 
       context 'when using example 3' do
@@ -259,11 +259,11 @@ describe 'bind::generate' do
           :lhs         => '$.0.10.10.IN-ADDR.ARPA.',
           :rhs         => 'dhcp-$.test.tld.',
         } }
-        it { should contain_concat__fragment('0.10.10.IN-ADDR.ARPA.PTR.2-100.generate').with(
+        it { should contain_concat__fragment('0.10.10.IN-ADDR.ARPA.PTR.2-100.generate').with({
           :ensure  => 'present',
           :target  => "#{confdir}/pri/0.10.10.IN-ADDR.ARPA.conf",
           :content => "$GENERATE 2-100 $.0.10.10.IN-ADDR.ARPA.   PTR dhcp-$.test.tld. ; ptr-record\n"
-        ) }
+        }) }
       end
     end
   end

--- a/spec/defines/bind_record_spec.rb
+++ b/spec/defines/bind_record_spec.rb
@@ -201,7 +201,7 @@ describe 'bind::record' do
         it 'should fail' do
           expect {
             should contain_concat__fragment('')
-          }.to raise_error(Puppet::Error, /"" does not match/)
+          }.to raise_error(Puppet::Error, /nil does not match/)
         end
       end
 

--- a/spec/defines/bind_zone_spec.rb
+++ b/spec/defines/bind_zone_spec.rb
@@ -168,16 +168,16 @@ describe 'bind::zone' do
              :transfer_source => '2.3.4.5',
            } }
 
-           it { should contain_concat("#{confdir}/zones/domain.tld.conf").with(
+           it { should contain_concat("#{confdir}/zones/domain.tld.conf").with({
              :owner => 'root',
              :group => 'root',
              :mode  => '0644'
-           ) }
-           it { should contain_concat__fragment('bind.zones.domain.tld').with(
+           }) }
+           it { should contain_concat__fragment('bind.zones.domain.tld').with({
              :ensure  => 'present',
              :target  => "#{confdir}/zones/domain.tld.conf",
              :content => "# File managed by puppet\nzone domain.tld IN {\n  type slave;\n    masters { 1.2.3.4; };\n    allow-query { any; };\n    transfer-source 2.3.4.5;\n  };\n"
-           ) }
+           }) }
          end
 
          context 'when master' do
@@ -190,29 +190,29 @@ describe 'bind::zone' do
              :zone_notify  => ['1.1.1.1', '2.2.2.2']
            } }
 
-           it { should contain_concat("#{confdir}/zones/domain.tld.conf").with(
+           it { should contain_concat("#{confdir}/zones/domain.tld.conf").with({
              :owner => 'root',
              :group => 'root',
              :mode  => '0644'
-           ) }
-           it { should contain_concat__fragment('bind.zones.domain.tld').with(
+           }) }
+           it { should contain_concat__fragment('bind.zones.domain.tld').with({
              :ensure  => 'present',
              :target  => "#{confdir}/zones/domain.tld.conf",
              :content => "# File managed by puppet\nzone \"domain.tld\" IN {\n  type master;\n  file \"#{confdir}/pri/domain.tld.conf\";\n  allow-transfer { none; };\n  allow-query { any; };\n  notify yes;\n    also-notify { 1.1.1.1; 2.2.2.2; };\n  };\n"
-           ) }
-           it { should contain_concat("#{confdir}/pri/domain.tld.conf").with(
+           }) }
+           it { should contain_concat("#{confdir}/pri/domain.tld.conf").with({
              :owner => 'root',
              :group => bind_group,
              :mode  => '0664'
-           ) }
-           it { should contain_concat__fragment('00.bind.domain.tld').with(
+           }) }
+           it { should contain_concat__fragment('00.bind.domain.tld').with({
              :ensure  => 'present',
              :target  => "#{confdir}/pri/domain.tld.conf",
              :content => "; File managed by puppet\n$TTL 60\n@ IN SOA domain.tld. admin@example.com. (\n      123456  ; serial\n      3h ; refresh\n      1h   ; retry\n      1w; expiracy\n      60 )   ; TTL\n      IN NS ns.tld.\n"
-           ) }
-           it { should contain_file("#{confdir}/pri/domain.tld.conf.d").with(
+           }) }
+           it { should contain_file("#{confdir}/pri/domain.tld.conf.d").with({
              :ensure => 'absent'
-           ) }
+           }) }
          end
        end
 
@@ -221,12 +221,12 @@ describe 'bind::zone' do
            :ensure => 'absent'
          } }
 
-         it { should contain_file("#{confdir}/pri/domain.tld.conf").with(
+         it { should contain_file("#{confdir}/pri/domain.tld.conf").with({
            :ensure => 'absent'
-         ) }
-         it { should contain_file("#{confdir}/zones/domain.tld.conf").with(
+         }) }
+         it { should contain_file("#{confdir}/zones/domain.tld.conf").with({
            :ensure => 'absent'
-         ) }
+         }) }
        end
     end
   end

--- a/spec/defines/bind_zone_spec.rb
+++ b/spec/defines/bind_zone_spec.rb
@@ -208,7 +208,7 @@ describe 'bind::zone' do
            it { should contain_concat__fragment('00.bind.domain.tld').with(
              :ensure  => 'present',
              :target  => "#{confdir}/pri/domain.tld.conf",
-             :content => "; File managed by puppet\n$TTL 60\n@ IN SOA domain.tld. admin@example.com. (\n      123456  ; serial\n      3h ; refresh\n      1h   ; retry\n      1w; expiracy\n      60 )   ; TTL\n      IN NS ns.tld.\n$ORIGIN .\n"
+             :content => "; File managed by puppet\n$TTL 60\n@ IN SOA domain.tld. admin@example.com. (\n      123456  ; serial\n      3h ; refresh\n      1h   ; retry\n      1w; expiracy\n      60 )   ; TTL\n      IN NS ns.tld.\n"
            ) }
            it { should contain_file("#{confdir}/pri/domain.tld.conf.d").with(
              :ensure => 'absent'


### PR DESCRIPTION
Linting was necessary as tests were complaining about empty string
initialisation. Some modification had to be done as well in unit tests.