### PR TITLE
do not set transfer-source if undef.

### DIFF
--- a/templates/zone-slave.erb
+++ b/templates/zone-slave.erb
@@ -7,7 +7,7 @@ zone <%= @name %> IN {
   masters { <%= @zone_masters %>; };
   <% end -%>
   allow-query { any; };
-  <% if @transfer_source != '' -%>
+  <% if @transfer_source and @transfer_source != '' -%>
   transfer-source <%= @transfer_source %>;
   <% end -%>
 };


### PR DESCRIPTION
 it breaks bind with a default (transfer_source = undef) configuration. If a parameter is not set and should not appear, we shouldn't set it to an empty string