### PR TITLE
Specify order in fragments

### DIFF
--- a/manifests/record.pp
+++ b/manifests/record.pp
@@ -47,6 +47,7 @@ define bind::record (
     ensure  => $ensure,
     target  => "${bind::params::pri_directory}/${zone}.conf",
     content => template($content_template),
+    order   => '10',
     notify  => Service['bind9'],
   }
 

--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -138,6 +138,7 @@ define bind::zone (
             concat::fragment {"00.bind.${name}":
               ensure  => $ensure,
               target  => $conf_file,
+              order   => '01',
               content => template('bind/zone-header.erb'),
             }
           }


### PR DESCRIPTION
This fix a possible unordered zone file when adding records (I've seen it when adding PTR records automatically using bind::a)

Updated master, this should be easily mergeable, sorry for the fuss