### PR TITLE
bugfixed the record class, content_template variable

### DIFF
--- a/manifests/record.pp
+++ b/manifests/record.pp
@@ -50,7 +50,7 @@ define bind::record (
   if($content_template){
     warning '$content_template is deprecated. Please use $content parameter.'
     validate_string($content_template)
-    $record_content = template(content_template)
+    $record_content = template($content_template)
   }elsif($content){
     $record_content = $content
   }else{


### PR DESCRIPTION
I had an issue when creating a record with v1.1.3 :

```
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Could not find template 'content_template' at /etc/puppet/environments/production/modules/bind/manifests/record.pp:53
```