### PR TITLE
use systemctl on newer RedHat releases and more changes

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,6 +54,7 @@ class bind {
     command     => $bind::params::service_restart,
     onlyif      => "named-checkconf -jz ${bind::params::config_base_dir}/${bind::params::named_conf_name}",
     refreshonly => true,
+    require     => Service['bind9'],
     path        => $::path,
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,6 +8,10 @@
 # This modules is valid for Bind 9.7.1 (squeeze version).
 # For 9.7.2, it will be really limited (no view nor ACL support).
 #
+# = Parameters
+#
+# $chroot:: If the chroot version of bind should be used. Default: false
+#
 #
 # Example:
 #
@@ -43,7 +47,9 @@
 #   }
 # }
 #
-class bind {
+class bind(
+  $chroot = false,
+) {
   anchor { 'bind::begin': } ->
   class { '::bind::install': } ->
   class { '::bind::config': } ~>

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -28,7 +28,11 @@ class bind::params {
         $bind_group           = 'named'
         $service_has_status   = true
         $service_pattern      = undef
-        $service_restart      = '/etc/init.d/named reload'
+        if versioncmp($::operatingsystemmajrelease,'7') < 0 {
+          $service_restart      = '/etc/init.d/named reload'
+        } else {
+          $service_restart      = '/usr/bin/systemctl reload named'
+        }
         $config_base_dir      = '/etc'
         $named_conf_name      = 'named.conf'
         $named_local_name     = 'named.conf.local'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,22 +20,32 @@ class bind::params {
         $pri_directory        = '/etc/bind/pri'
         $keys_directory       = '/etc/bind/keys'
         $dynamic_directory    = '/etc/bind/dynamic'
+        if $bind::chroot {
+          fail('Chroot mode is not yet implemented for Debian in this module.')
+        }
     }
     elsif $::osfamily == 'RedHat' {
-        $package_name         = 'bind'
-        $service_name         = 'named'
+        if $bind::chroot {
+          $package_name         = 'bind-chroot'
+          $service_name         = 'named-chroot'
+          # moving this under named so it also is available within the chroot.
+          $named_local_name     = 'named/named.conf.local'
+        } else {
+          $package_name         = 'bind'
+          $service_name         = 'named'
+          $named_local_name     = 'named.conf.local'
+        }
         $bind_user            = 'named'
         $bind_group           = 'named'
         $service_has_status   = true
         $service_pattern      = undef
         if versioncmp($::operatingsystemmajrelease,'7') < 0 {
-          $service_restart      = '/etc/init.d/named reload'
+          $service_restart      = "/etc/init.d/${service_name} reload"
         } else {
-          $service_restart      = '/usr/bin/systemctl reload named'
+          $service_restart      = "/usr/bin/systemctl reload ${service_name}"
         }
         $config_base_dir      = '/etc'
         $named_conf_name      = 'named.conf'
-        $named_local_name     = 'named.conf.local'
         $zones_directory      = '/etc/named/zones'
         $pri_directory        = '/etc/named/pri'
         $keys_directory       = '/etc/named/keys'


### PR DESCRIPTION
* There is no /etc/init.d/named anymore.
* make the ordering more robust
* introduce usage for a chroot version