### PR TITLE
Add a new array allow_update_cidr in zone management

### DIFF
--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -19,24 +19,25 @@
 #  *$zone_notify*: IPs to use for also-notify entry
 #
 define bind::zone (
-  $ensure          = present,
-  $is_dynamic      = false,
-  $allow_update    = [],
-  $transfer_source = undef,
-  $zone_type       = 'master',
-  $zone_ttl        = undef,
-  $zone_contact    = undef,
-  $zone_serial     = undef,
-  $zone_refresh    = '3h',
-  $zone_retry      = '1h',
-  $zone_expiracy   = '1w',
-  $zone_ns         = [],
-  $zone_xfers      = undef,
-  $zone_masters    = undef,
-  $zone_forwarders = undef,
-  $zone_origin     = undef,
-  $zone_notify     = undef,
-  $is_slave        = false,
+  $ensure            = present,
+  $is_dynamic        = false,
+  $allow_update      = [],
+  $allow_update_cidr = [],
+  $transfer_source   = undef,
+  $zone_type         = 'master',
+  $zone_ttl          = undef,
+  $zone_contact      = undef,
+  $zone_serial       = undef,
+  $zone_refresh      = '3h',
+  $zone_retry        = '1h',
+  $zone_expiracy     = '1w',
+  $zone_ns           = [],
+  $zone_xfers        = undef,
+  $zone_masters      = undef,
+  $zone_forwarders   = undef,
+  $zone_origin       = undef,
+  $zone_notify       = undef,
+  $is_slave          = false,
 ) {
 
   include ::bind::params
@@ -48,6 +49,7 @@ define bind::zone (
   validate_bool($is_slave)
   validate_bool($is_dynamic)
   validate_array($allow_update)
+  validate_array($allow_update_cidr)
   validate_string($transfer_source)
   validate_string($zone_type)
   validate_string($zone_ttl)
@@ -60,7 +62,7 @@ define bind::zone (
 
   validate_string($zone_origin)
 
-  # add backwards support for is_slave parameter 
+  # add backwards support for is_slave parameter
   if ($is_slave) and ($zone_type == 'master') {
     warning('$is_slave is deprecated. You should set $zone_type = \'slave\'')
     $int_zone_type = 'slave'

--- a/templates/zone-master.erb
+++ b/templates/zone-master.erb
@@ -1,6 +1,6 @@
 <%-
-if @is_dynamic and @allow_update.empty?
-  raise(Puppet::ParseError, "allow_update is empty for dynamic zone '#{name}'")
+if @is_dynamic and (@allow_update.empty? and @allow_update_cidr.empty?)
+  raise(Puppet::ParseError, "Both allow_update and allow_update_cidr are empty for dynamic zone '#{name}'")
 end
 -%>
 # File managed by puppet
@@ -17,7 +17,8 @@ zone "<%= @name %>" IN {
   allow-transfer { none; };
 <% end -%>
 <% if @is_dynamic -%>
-  allow-update { key <%= Array(@allow_update).join('.; key ') -%>.; };
+  allow-update { <% if ![nil, '', :undef].include?(@allow_update) -%>key <%= Array(@allow_update).join('.; key ') -%>.;<% end
+    -%><% if ![nil, '', :undef].include?(@allow_update_cidr) -%> <%= Array(@allow_update_cidr).join('; ') -%>;<% end -%> };
 <% end -%>
   allow-query { any; };
   notify yes;


### PR DESCRIPTION
Add a new, dedicated array so we can specify more allow-update values like networks, a part from keys, as per http://www.zytrax.com/books/dns/ch7/xfer.html#allow-update

I created a new array to maintain backwards compatibility with the keys-only array and because they have slightly different syntax + different requirements