### PR TITLE
Make sure no forwarder is set on master/slave zone

### DIFF
--- a/spec/defines/bind_zone_spec.rb
+++ b/spec/defines/bind_zone_spec.rb
@@ -177,7 +177,7 @@ describe 'bind::zone' do
            it { should contain_concat__fragment('bind.zones.domain.tld').with({
              :ensure  => 'present',
              :target  => "#{confdir}/zones/domain.tld.conf",
-             :content => "# File managed by puppet\nzone domain.tld IN {\n  type slave;\n  masters { 1.2.3.4; };\n  allow-query { any; };\n    transfer-source 2.3.4.5;\n  };\n"
+             :content => "# File managed by puppet\nzone domain.tld IN {\n  type slave;\n  masters { 1.2.3.4; };\n  allow-query { any; };\n    transfer-source 2.3.4.5;\n    forwarders { };\n};\n"
            }) }
          end
 
@@ -217,7 +217,7 @@ describe 'bind::zone' do
            it { should contain_concat__fragment('bind.zones.domain.tld').with({
              :ensure  => 'present',
              :target  => "#{confdir}/zones/domain.tld.conf",
-             :content => "# File managed by puppet\nzone \"domain.tld\" IN {\n  type master;\n  file \"#{confdir}/pri/domain.tld.conf\";\n  allow-transfer { none; };\n  allow-query { any; };\n  notify yes;\n  also-notify { 1.1.1.1; 2.2.2.2; };\n};\n"
+             :content => "# File managed by puppet\nzone \"domain.tld\" IN {\n  type master;\n  file \"#{confdir}/pri/domain.tld.conf\";\n  allow-transfer { none; };\n  allow-query { any; };\n  notify yes;\n  also-notify { 1.1.1.1; 2.2.2.2; };\n  forwarders { };\n};\n"
            }) }
            it { should contain_concat("#{confdir}/pri/domain.tld.conf").with({
              :owner => 'root',

--- a/templates/zone-master.erb
+++ b/templates/zone-master.erb
@@ -24,4 +24,5 @@ zone "<%= @name %>" IN {
 <% if @zone_notify and not @zone_notify.empty? -%>
   also-notify { <%= Array(@zone_notify).join('; ') -%>; };
 <% end -%>
+  forwarders { };
 };

--- a/templates/zone-slave.erb
+++ b/templates/zone-slave.erb
@@ -6,4 +6,5 @@ zone <%= @name %> IN {
   <% if @transfer_source and @transfer_source != '' -%>
   transfer-source <%= @transfer_source %>;
   <% end -%>
+  forwarders { };
 };


### PR DESCRIPTION
In case bind9 is master for a zone and has a zone delegation inside the
zone, having a forwarder defined makes the resolving of the NS record
fail for some reason if the NS target is inside the zone.
Apparently bind will try to forward the resolution of the NS target and
this will fail since the master for the zone is actually itself and not
the forwarder.

Removing the forwarder will actually make bind behave correctly in all
cases:
- using the cache for the name if present in it
- resolving locally if it is master for the zone
- forwarding the request if none of the previous apply